### PR TITLE
fix badge pointing at chef-cookbooks which is a 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Description
 ===========
 [![Cookbook Version](http://img.shields.io/cookbook/v/build-essential.svg)][cookbook]
-[![Build Status](http://img.shields.io/travis/chef-cookbooks/build-essential.svg)][travis]
+[![Build Status](http://img.shields.io/travis/opscode-cookbooks/build-essential.svg)][travis]
 
 [cookbook]: https://community.chef.io/cookbooks/build-essential
 [travis]: http://travis-ci.org/chef-cookbooks/build-essential


### PR DESCRIPTION
Right now the badge is pointing at -

![broken badge](http://img.shields.io/travis/chef-cookbooks/build-essential.svg)

Whereas what we want is -

![broken badge](http://img.shields.io/travis/opscode-cookbooks/build-essential.svg)

Simple fix to point it at the right place. :heart: 